### PR TITLE
Removed UFunctions from uses list

### DIFF
--- a/UMain.pas
+++ b/UMain.pas
@@ -32,7 +32,7 @@ var
 
 implementation
  uses
-   System.Win.Registry, UFunctions;
+   System.Win.Registry;
 {$R *.dfm}
 
 procedure TFrmMain.CreateParams(var Params: TCreateParams);


### PR DESCRIPTION
The reason for removing `UFunctions` is that the unit doesn't exist in this project and it isn't required in this project either.